### PR TITLE
Add support for anonymous classes, reuse normalized maxPropertyCount value in error message

### DIFF
--- a/SlevomatCodingStandard/Sniffs/Classes/PropertyPerClassLimitSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/PropertyPerClassLimitSniff.php
@@ -6,6 +6,7 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use SlevomatCodingStandard\Helpers\ClassHelper;
 use SlevomatCodingStandard\Helpers\SniffSettingsHelper;
+use function count;
 use function sprintf;
 use const T_ANON_CLASS;
 use const T_CLASS;
@@ -34,7 +35,7 @@ final class PropertyPerClassLimitSniff implements Sniff
 	 */
 	public function process(File $file, $classPointer): void
 	{
-		$propertiesCount = ClassHelper::getPropertiesCount($file, $classPointer);
+		$propertiesCount = count(ClassHelper::getPropertyPointers($file, $classPointer));
 
 		if ($propertiesCount <= SniffSettingsHelper::normalizeInteger($this->maxPropertyCount)) {
 			return;

--- a/SlevomatCodingStandard/Sniffs/Classes/PropertyPerClassLimitSniff.php
+++ b/SlevomatCodingStandard/Sniffs/Classes/PropertyPerClassLimitSniff.php
@@ -30,26 +30,23 @@ final class PropertyPerClassLimitSniff implements Sniff
 
 	/**
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-	 * @param File $file
+	 * @param File $phpcsFile
 	 * @param int $classPointer
 	 */
-	public function process(File $file, $classPointer): void
+	public function process(File $phpcsFile, $classPointer): void
 	{
-		$propertiesCount = count(ClassHelper::getPropertyPointers($file, $classPointer));
-
-		if ($propertiesCount <= SniffSettingsHelper::normalizeInteger($this->maxPropertyCount)) {
+		$maxPropertyCount = SniffSettingsHelper::normalizeInteger($this->maxPropertyCount);
+		$numberOfProperties = count(ClassHelper::getPropertyPointers($phpcsFile, $classPointer));
+		if ($numberOfProperties <= $maxPropertyCount) {
 			return;
 		}
-
-		$tokenType = $file->getTokens()[$classPointer]['content'];
 		$errorMessage = sprintf(
-			'"%s" has too many properties: %d. Can be up to %d properties.',
-			$tokenType,
-			$propertiesCount,
-			$this->maxPropertyCount
+			'%s has too many properties: %d. Can be up to %d properties.',
+			$phpcsFile->getTokens()[$classPointer]['content'],
+			$numberOfProperties,
+			$maxPropertyCount
 		);
-
-		$file->addError($errorMessage, $classPointer, self::CODE_PROPERTY_PER_CLASS_LIMIT);
+		$phpcsFile->addError($errorMessage, $classPointer, self::CODE_PROPERTY_PER_CLASS_LIMIT);
 	}
 
 }

--- a/tests/Helpers/ClassHelperTest.php
+++ b/tests/Helpers/ClassHelperTest.php
@@ -115,4 +115,35 @@ class ClassHelperTest extends TestCase
 		self::assertSame(28, ClassHelper::getClassPointer($phpcsFile, $methodInBarPointer));
 	}
 
+	public function testGetClassPointersWithoutNamespace(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/propertyWithoutNamespace.php');
+
+		$fooClassPointer = $this->findClassPointerByName($phpcsFile, 'FooClass');
+		$fooPropertyPointer = $this->findPropertyPointerByName($phpcsFile, 'fooProperty');
+		self::assertSame([$fooPropertyPointer], ClassHelper::getPropertyPointers($phpcsFile, $fooClassPointer));
+	}
+
+	public function testGetClassPointersWithNamespace(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/propertyWithNamespace.php');
+
+		$fooClassPointer = $this->findClassPointerByName($phpcsFile, 'FooClass');
+		$fooPropertyPointer = $this->findPropertyPointerByName($phpcsFile, 'fooProperty');
+		self::assertSame([$fooPropertyPointer], ClassHelper::getPropertyPointers($phpcsFile, $fooClassPointer));
+	}
+
+	public function testGetClassPointersWithNestedProperty(): void
+	{
+		$phpcsFile = $this->getCodeSnifferFile(__DIR__ . '/data/classWithNestedProperty.php');
+
+		$fooClassPointer = $this->findClassPointerByName($phpcsFile, 'FooClass');
+		$fooPropertyPointer = $this->findPropertyPointerByName($phpcsFile, 'fooProperty');
+		self::assertSame([$fooPropertyPointer], ClassHelper::getPropertyPointers($phpcsFile, $fooClassPointer));
+
+		$anonymousClassPointer = $this->findPointerByLineAndType($phpcsFile, 9, T_ANON_CLASS);
+		$anonymousClassPropertyPointer = $this->findPropertyPointerByName($phpcsFile, 'anonymousClassProperty');
+		self::assertSame([$anonymousClassPropertyPointer], ClassHelper::getPropertyPointers($phpcsFile, $anonymousClassPointer));
+	}
+
 }

--- a/tests/Helpers/data/classWithNestedProperty.php
+++ b/tests/Helpers/data/classWithNestedProperty.php
@@ -1,0 +1,14 @@
+<?php
+
+class FooClass
+{
+	private $fooProperty;
+
+	public function classMethod()
+	{
+		return new class {
+			public $anonymousClassProperty;
+		};
+	}
+
+}

--- a/tests/Sniffs/Classes/data/propertyPerClassLimitNoErrors.php
+++ b/tests/Sniffs/Classes/data/propertyPerClassLimitNoErrors.php
@@ -2,13 +2,44 @@
 
 class FineAmountOfPropertiesClass
 {
-	/**
-	 * @var string
-	 */
-	protected $string1;
+	protected $property1;
+	protected $property2;
+	protected $property3;
+	protected $property4;
+	protected $property5;
+	protected $property6;
+	protected $property7;
+	protected $property8;
+	protected $property9;
+	protected $property10;
 
-	/**
-	 * @var string
-	 */
-	protected $string2;
+	protected function anonymousClassMethod()
+	{
+		return new class {
+			protected $anonymousProperty1;
+		};
+	}
+}
+
+function FineAmountOfPropertiesClass()
+{
+	return new class {
+		protected $property1;
+		protected $property2;
+		protected $property3;
+		protected $property4;
+		protected $property5;
+		protected $property6;
+		protected $property7;
+		protected $property8;
+		protected $property9;
+		protected $property10;
+
+		protected function anonymousClassMethod()
+		{
+			return new class {
+				protected $anonymousProperty1;
+			};
+		}
+	};
 }


### PR DESCRIPTION
This PR adds the following improvements to this branch:
* Add support for anonymous classes; see the [corresponding review comment](https://github.com/slevomat/coding-standard/pull/1108#pullrequestreview-649760204).
* Reuse normalized maxPropertyCount value in error message; see the [corresponding review comment](https://github.com/slevomat/coding-standard/pull/1108#pullrequestreview-649779991).